### PR TITLE
chore: Migrate talent synth.py to bazel

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -14,23 +14,16 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import synthtool as s
-import synthtool.gcp as gcp
 import synthtool.languages.java as java
-
-gapic = gcp.GAPICGenerator()
-common_templates = gcp.CommonTemplates()
 
 versions = ['v4beta1']
 service = 'talent'
 
 for version in versions:
-  java.gapic_library(
-    service=service,
-    version=version,
-    config_pattern='/google/cloud/talent/artman_talent_{version}.yaml',
-    package_pattern='com.google.cloud.{service}.{version}',
-    gapic=gapic,
+  library = java.bazel_library(
+      service=service,
+      version=version,
+      bazel_target=f'//google/cloud/{service}/{version}:google-cloud-{service}-{version}-java',
   )
 
 java.common_templates()


### PR DESCRIPTION
As suggested in https://github.com/googleapis/java-talent/pull/100, this PR only updates the `synth.py` itself to use bazel. 

The updated generated code will be published separately by Yoshi, because it includes breaking changes in resource names, caused not by the bazel migration but by the changes in the generator itself.

